### PR TITLE
remove Rails 5.2 deprecation warning

### DIFF
--- a/lib/vestal_versions/versions.rb
+++ b/lib/vestal_versions/versions.rb
@@ -31,7 +31,7 @@ module VestalVersions
       return [] if from_number.nil? || to_number.nil?
 
       condition = (from_number == to_number) ? to_number : Range.new(*[from_number, to_number].sort)
-      where(:number => condition).order("#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}").to_a
+      where(:number => condition).order(Arel.sql("#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}")).to_a
     end
 
     # Returns all version records created before the version associated with the given value.

--- a/vestal_versions.gemspec
+++ b/vestal_versions.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'http://github.com/laserlemon/vestal_versions'
   gem.license     = 'MIT'
 
-  gem.add_dependency 'activerecord', '>= 3', '< 6'
-  gem.add_dependency 'activesupport', '>= 3', '< 6'
+  gem.add_dependency 'activerecord', '>= 3', '< 7'
+  gem.add_dependency 'activesupport', '>= 3', '< 7'
 
   gem.add_development_dependency 'bundler', '~> 1.0'
   gem.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Dangerous query method (method whose arguments are used as raw SQL)i
called with non-attribute argument(s): "versions.\"number\" DESC".
Non-attribute arguments will be disallowed in Rails 6.0.
This method should not be called with user-provided values,
such as request parameters or model attributes.
Known-safe values can be passed by wrapping them in Arel.sql()